### PR TITLE
Added Highlight to add configuration in 'config.yml' 

### DIFF
--- a/installation.markdown
+++ b/installation.markdown
@@ -84,6 +84,17 @@ public function registerBundles()
 }
 {% endhighlight %}
 
+Add Configuration in `config.yml`:
+
+{% highlight yaml %}
+admingenerator_generator:
+    twig:
+        date_format: 'd-M-Y'
+        number_format:
+            decimal: 2
+            decimal_point: " , "
+{% endhighlight %}
+
 ### Install SensioGeneratorBundle (if you're not on a symfony-standard)
 
 Add the bundle as a submodule:


### PR DESCRIPTION
Added some highlight to "Full Custom Installation" to add configuration in config.yml

when installing AdmingeneratorGeneratorBundle to avoid error when installing KnpMenu.

I think this is due to the recent merge https://github.com/cedriclombardot/AdmingeneratorGeneratorBundle/pull/106

This is the error that I ran into without the configuration in config.yml
###### 

Cloning into /var/www/klikevent/vendor//KnpMenu...
remote: Counting objects: 1001, done.
remote: Compressing objects: 100% (325/325), done.
remote: Total 1001 (delta 461), reused 935 (delta 398)
Receiving objects: 100% (1001/1001), 139.63 KiB | 95 KiB/s, done.
Resolving deltas: 100% (461/461), done.
f7970583d4da8776c037e2d49878d8160361e373
HEAD is now at f797058 Updated the changelog

  [ErrorException]  
  Notice: Undefined index: twig in /var/www/klikevent/vendor/bundles/Admingenerator/GeneratorBundle/DependencyInjection/AdmingeneratorGeneratorExtension.php line 44  
                                                                                                                                         [ErrorException]  
  Notice: Undefined index: twig in /var/www/klikevent/vendor/bundles/Admingenerator/GeneratorBundle/DependencyInjection/AdmingeneratorGeneratorExtension.php line 44  
