### PR TITLE
Makes filters in List view accept GET parameters too, for dbType entity

### DIFF
--- a/documentation.markdown
+++ b/documentation.markdown
@@ -30,6 +30,8 @@ Of course if you want to contribute, you're welcome
 * [Actions](documentation/list.html#actions)
 * [Batch Actions](documentation/list-batch-actions.html)
 * [Edit query](documentation/list.html#edit-query)
+* [Predefined filters](documentation/list.html#predefined-filters)
+
 
 ### Nestedset List (only for propel)
 

--- a/documentation.markdown
+++ b/documentation.markdown
@@ -30,7 +30,7 @@ Of course if you want to contribute, you're welcome
 * [Actions](documentation/list.html#actions)
 * [Batch Actions](documentation/list-batch-actions.html)
 * [Edit query](documentation/list.html#edit-query)
-* [Predefined filters](documentation/list.html#predefined-filters)
+* [Predefined filters](documentation/list.html#pre-defined-filters-filter-on-dbtype-entity-works-only-with-doctrine)
 
 
 ### Nestedset List (only for propel)

--- a/documentation/list.markdown
+++ b/documentation/list.markdown
@@ -278,6 +278,34 @@ protected function getQuery()
 
 If you want to have by default all the movies published only. 
 
+
+## Pre-defined filters (filter on dbType Entity works only with doctrine)
+
+You can link to a pre-filtered list.
+
+Consider a list of Users and a list of Comments.
+For each user, let's create a link - in the user List - to the user's comments - in the Comment List.
+
+First, we add a new display field in YourBundle/Resources/config/User-generator.yml :
+
+{% highlight yaml %}
+builders:
+  list:
+    params:
+      display: [..., object_navigation]
+{% endhighlight %}
+
+Then we customize this field in YourBundle/Resources/views/UserList/index.html.twig :
+
+{% highlight html+django %}
+{{ "{%" }} extends_admingenerated "NamespaceYourBundle:UserList:index.html.twig" %}
+{{ "{%" }} block list_td_column_object_navigation %}
+    <a href="{{ path('Namespace_YourBundle_Comment_filters', { 'user' : User.id  } ) }}">
+        <img src="{{ asset('bundles/namespaceyourbundle/images/icons/comment.png') }}" title="All comments for this user">
+    </a>
+{{ "{%" }} endblock %}
+{% endhighlight %}
+
 ## Configuration
 
 ### Date format


### PR DESCRIPTION
Here is the doc entry for this pull request : https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/pull/135

I don't know how to check how the doc entry will look like... All the doc markup seems broken in github for me.  I hope it's ok.
